### PR TITLE
serde_cbor_core replaces serde_ipld_dagcbor

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,6 +1,10 @@
 default:
   just --list
 
+# Build and install CLI
+install_cli:
+    cargo install --path rust/szdt-cli
+
 # Build WASM bindings for web
 build_szdt_web:
     cd rust/szdt-wasm && wasm-pack build --target web --out-dir pkg/web

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -65,12 +65,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "base-x"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
-
-[[package]]
 name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,20 +181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "cid"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3147d8272e8fa0ccd29ce51194dd98f79ddfb8191ba9e3409884e751798acf3a"
-dependencies = [
- "core2",
- "multibase",
- "multihash",
- "serde",
- "serde_bytes",
- "unsigned-varint",
-]
-
-[[package]]
 name = "clap"
 version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,15 +265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,26 +315,6 @@ name = "data-encoding"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
-
-[[package]]
-name = "data-encoding-macro"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ce6c96ea0102f01122a185683611bd5ac8d99e62bc59dd12e6bda344ee673d"
-dependencies = [
- "data-encoding",
- "data-encoding-macro-internal",
-]
-
-[[package]]
-name = "data-encoding-macro-internal"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
-dependencies = [
- "data-encoding",
- "syn",
-]
 
 [[package]]
 name = "der"
@@ -555,17 +506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
-name = "ipld-core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "104718b1cc124d92a6d01ca9c9258a7df311405debb3408c445a36452f9bf8db"
-dependencies = [
- "cid",
- "serde",
- "serde_bytes",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,12 +560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
-name = "memchr"
-version = "2.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,28 +581,6 @@ dependencies = [
  "phf",
  "phf_shared",
  "unicase",
-]
-
-[[package]]
-name = "multibase"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3539ec3c1f04ac9748a260728e855f261b4977f5c3406612c884564f329404"
-dependencies = [
- "base-x",
- "data-encoding",
- "data-encoding-macro",
-]
-
-[[package]]
-name = "multihash"
-version = "0.19.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
-dependencies = [
- "core2",
- "serde",
- "unsigned-varint",
 ]
 
 [[package]]
@@ -915,11 +827,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.17"
+name = "serde_cbor_core"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
+checksum = "91f40eecb4e09aae229a97907bdaa29a49ccac0c5a88e158f3720dc883f7a081"
 dependencies = [
+ "cbor4ii 0.2.14",
+ "scopeguard",
  "serde",
 ]
 
@@ -932,18 +846,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "serde_ipld_dagcbor"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99600723cf53fb000a66175555098db7e75217c415bdd9a16a65d52a19dcc4fc"
-dependencies = [
- "cbor4ii 0.2.14",
- "ipld-core",
- "scopeguard",
- "serde",
 ]
 
 [[package]]
@@ -1036,7 +938,6 @@ dependencies = [
  "rand 0.9.1",
  "rusqlite",
  "serde",
- "serde_ipld_dagcbor",
  "szdt-core",
  "tempfile",
  "thiserror 2.0.12",
@@ -1054,7 +955,7 @@ dependencies = [
  "ed25519-dalek",
  "mime_guess2",
  "serde",
- "serde_ipld_dagcbor",
+ "serde_cbor_core",
  "tempfile",
  "thiserror 2.0.12",
 ]
@@ -1066,7 +967,7 @@ dependencies = [
  "cbor4ii 1.0.0",
  "js-sys",
  "serde-wasm-bindgen",
- "serde_ipld_dagcbor",
+ "serde_cbor_core",
  "szdt-core",
  "wasm-bindgen",
  "web-sys",
@@ -1173,12 +1074,6 @@ name = "unicode-width"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
-
-[[package]]
-name = "unsigned-varint"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb066959b24b5196ae73cb057f45598450d2c5f71460e98c49b738086eff9c06"
 
 [[package]]
 name = "utf8parse"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,6 @@ mime_guess2 = "2.3.1"
 rand = { version = "0.9.1" }
 rusqlite = "0.37.0"
 serde = { version = "1.0.219", features = ["derive"] }
-serde_ipld_dagcbor = "=0.6.3"
+serde_cbor_core = "0.1.0"
 thiserror = "2.0.12"
 tempfile = "3.19.1"

--- a/rust/szdt-cli/Cargo.toml
+++ b/rust/szdt-cli/Cargo.toml
@@ -17,7 +17,6 @@ dirs = { workspace = true }
 mime_guess2 = { workspace = true }
 rusqlite = { workspace = true }
 serde = { workspace = true }
-serde_ipld_dagcbor = { workspace = true }
 thiserror = { workspace = true }
 rand = { workspace = true }
 

--- a/rust/szdt-core/Cargo.toml
+++ b/rust/szdt-core/Cargo.toml
@@ -13,7 +13,7 @@ data-encoding = { workspace = true }
 ed25519-dalek = { workspace = true }
 mime_guess2 = { workspace = true }
 serde = { workspace = true }
-serde_ipld_dagcbor = { workspace = true }
+serde_cbor_core = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/rust/szdt-core/src/bytes.rs
+++ b/rust/szdt-core/src/bytes.rs
@@ -57,12 +57,12 @@ impl Visitor<'_> for BytesVisitor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_ipld_dagcbor;
+    use serde_cbor_core;
 
     #[test]
     fn test_bytes_serialized_as_byte_string() {
         let bytes = Bytes(vec![1, 2, 3, 4, 5]);
-        let serialized = serde_ipld_dagcbor::to_vec(&bytes).unwrap();
+        let serialized = serde_cbor_core::to_vec(&bytes).unwrap();
 
         // Check that the first byte indicates a byte string (major type 2)
         // In CBOR, major type 2 is for byte strings, encoded as 0b010xxxxx
@@ -73,7 +73,7 @@ mod tests {
         );
 
         // Verify round-trip deserialization works
-        let deserialized: Bytes = serde_ipld_dagcbor::from_slice(&serialized).unwrap();
+        let deserialized: Bytes = serde_cbor_core::from_slice(&serialized).unwrap();
         assert_eq!(bytes, deserialized);
     }
 }

--- a/rust/szdt-core/src/cbor_seq.rs
+++ b/rust/szdt-core/src/cbor_seq.rs
@@ -15,9 +15,9 @@ impl<R: BufRead> CborSeqReader<R> {
 
     /// Deserialize next block
     pub fn read_block<T: DeserializeOwned>(&mut self) -> Result<T, Error> {
-        let result: T = match serde_ipld_dagcbor::de::from_reader_once(&mut self.reader) {
+        let result: T = match serde_cbor_core::de::from_reader_once(&mut self.reader) {
             Ok(value) => value,
-            Err(serde_ipld_dagcbor::DecodeError::Eof) => return Err(Error::Eof),
+            Err(serde_cbor_core::DecodeError::Eof) => return Err(Error::Eof),
             Err(err) => return Err(Error::CborDecode(err.to_string())),
         };
         Ok(result)
@@ -41,7 +41,7 @@ impl<W: Write> CborSeqWriter<W> {
 
     /// Serialize next block
     pub fn write_block<T: Serialize>(&mut self, block: &T) -> Result<(), Error> {
-        serde_ipld_dagcbor::ser::to_writer(&mut self.writer, block)?;
+        serde_cbor_core::ser::to_writer(&mut self.writer, block)?;
         Ok(())
     }
 

--- a/rust/szdt-core/src/error.rs
+++ b/rust/szdt-core/src/error.rs
@@ -63,26 +63,26 @@ pub enum Error {
     Eof,
 }
 
-impl From<serde_ipld_dagcbor::DecodeError<std::io::Error>> for Error {
-    fn from(err: serde_ipld_dagcbor::DecodeError<std::io::Error>) -> Self {
+impl From<serde_cbor_core::DecodeError<std::io::Error>> for Error {
+    fn from(err: serde_cbor_core::DecodeError<std::io::Error>) -> Self {
         Error::CborDecode(err.to_string())
     }
 }
 
-impl From<serde_ipld_dagcbor::DecodeError<Infallible>> for Error {
-    fn from(err: serde_ipld_dagcbor::DecodeError<Infallible>) -> Self {
+impl From<serde_cbor_core::DecodeError<Infallible>> for Error {
+    fn from(err: serde_cbor_core::DecodeError<Infallible>) -> Self {
         Error::CborDecode(err.to_string())
     }
 }
 
-impl From<serde_ipld_dagcbor::EncodeError<TryReserveError>> for Error {
-    fn from(err: serde_ipld_dagcbor::EncodeError<TryReserveError>) -> Self {
+impl From<serde_cbor_core::EncodeError<TryReserveError>> for Error {
+    fn from(err: serde_cbor_core::EncodeError<TryReserveError>) -> Self {
         Error::CborEncode(err.to_string())
     }
 }
 
-impl From<serde_ipld_dagcbor::EncodeError<std::io::Error>> for Error {
-    fn from(err: serde_ipld_dagcbor::EncodeError<std::io::Error>) -> Self {
+impl From<serde_cbor_core::EncodeError<std::io::Error>> for Error {
+    fn from(err: serde_cbor_core::EncodeError<std::io::Error>) -> Self {
         Error::CborEncode(err.to_string())
     }
 }

--- a/rust/szdt-core/src/hash.rs
+++ b/rust/szdt-core/src/hash.rs
@@ -139,7 +139,7 @@ mod tests {
     #[test]
     fn test_hash_serializes_as_cbor_byte_string() {
         let hash = Hash::new(b"test data");
-        let serialized = serde_ipld_dagcbor::to_vec(&hash).expect("Failed to serialize hash");
+        let serialized = serde_cbor_core::to_vec(&hash).expect("Failed to serialize hash");
 
         // CBOR byte strings with length 32 should start with 0x58 0x20
         // 0x58 = major type 2 (byte string) with additional info 24 (1-byte length follows)
@@ -164,11 +164,11 @@ mod tests {
         let original_hash = Hash::new(b"roundtrip test data");
 
         // Serialize
-        let serialized = serde_ipld_dagcbor::to_vec(&original_hash).expect("Failed to serialize");
+        let serialized = serde_cbor_core::to_vec(&original_hash).expect("Failed to serialize");
 
         // Deserialize
         let deserialized_hash: Hash =
-            serde_ipld_dagcbor::from_slice(&serialized).expect("Failed to deserialize");
+            serde_cbor_core::from_slice(&serialized).expect("Failed to deserialize");
 
         assert_eq!(
             original_hash, deserialized_hash,

--- a/rust/szdt-core/src/link.rs
+++ b/rust/szdt-core/src/link.rs
@@ -1,7 +1,7 @@
 use crate::error::Error;
 use crate::hash::Hash;
 use serde::Serialize;
-use serde_ipld_dagcbor;
+use serde_cbor_core;
 
 pub trait ToLink {
     fn to_link(&self) -> Result<Hash, Error>;
@@ -14,7 +14,7 @@ where
     /// Generate a content-addressed link from the given data.
     /// Serializes content to CBOR and generates a Blake3 hash for that CBOR data.
     fn to_link(&self) -> Result<Hash, Error> {
-        let cbor_data = serde_ipld_dagcbor::to_vec(self)?;
+        let cbor_data = serde_cbor_core::to_vec(self)?;
         let hash = Hash::new(&cbor_data);
         Ok(hash)
     }

--- a/rust/szdt-core/src/memo.rs
+++ b/rust/szdt-core/src/memo.rs
@@ -222,7 +222,7 @@ mod tests {
         let body_content = "Hello World";
         let memo = Memo::for_body(body_content).unwrap();
 
-        let cbor_bytes = serde_ipld_dagcbor::to_vec(body_content).unwrap();
+        let cbor_bytes = serde_cbor_core::to_vec(body_content).unwrap();
         assert_eq!(memo.protected.src, Hash::new(&cbor_bytes));
     }
 
@@ -329,10 +329,10 @@ mod tests {
         let memo = Memo::for_body(body_content).unwrap();
 
         // Serialize memo to CBOR
-        let cbor_bytes = serde_ipld_dagcbor::to_vec(&memo).unwrap();
+        let cbor_bytes = serde_cbor_core::to_vec(&memo).unwrap();
 
         // Deserialize back to a generic Value to check the type field
-        let value: cbor4ii::core::Value = serde_ipld_dagcbor::from_slice(&cbor_bytes).unwrap();
+        let value: cbor4ii::core::Value = serde_cbor_core::from_slice(&cbor_bytes).unwrap();
 
         if let cbor4ii::core::Value::Map(entries) = value {
             let type_key = cbor4ii::core::Value::Text("type".to_string());

--- a/rust/szdt-wasm/Cargo.toml
+++ b/rust/szdt-wasm/Cargo.toml
@@ -13,7 +13,7 @@ wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde-wasm-bindgen = "0.6"
 wee_alloc = "0.4"
-serde_ipld_dagcbor = { workspace = true }
+serde_cbor_core = { workspace = true }
 cbor4ii = { workspace = true }
 
 [dependencies.web-sys]

--- a/rust/szdt-wasm/src/cbor_seq.rs
+++ b/rust/szdt-wasm/src/cbor_seq.rs
@@ -70,7 +70,7 @@ impl CborSeqReader {
 
         // Serialize the value back to CBOR
         let cbor_bytes =
-            serde_ipld_dagcbor::to_vec(&value).map_err(|e| JsError::new(&e.to_string()))?;
+            serde_cbor_core::to_vec(&value).map_err(|e| JsError::new(&e.to_string()))?;
         Ok(cbor_bytes)
     }
 
@@ -128,7 +128,7 @@ impl CborSeqWriter {
     pub fn write_raw(&mut self, cbor_data: &[u8]) -> Result<(), JsError> {
         // Parse the CBOR data to validate it
         let _value: Value =
-            serde_ipld_dagcbor::from_slice(cbor_data).map_err(|e| JsError::new(&e.to_string()))?;
+            serde_cbor_core::from_slice(cbor_data).map_err(|e| JsError::new(&e.to_string()))?;
 
         // Write directly to our buffer
         self.data.extend_from_slice(cbor_data);
@@ -179,7 +179,7 @@ impl CborSeqWriter {
 #[wasm_bindgen]
 pub fn parse_cbor(data: &[u8]) -> Result<JsValue, JsError> {
     let value: Value =
-        serde_ipld_dagcbor::from_slice(data).map_err(|e| JsError::new(&e.to_string()))?;
+        serde_cbor_core::from_slice(data).map_err(|e| JsError::new(&e.to_string()))?;
     let js_value =
         serde_wasm_bindgen::to_value(&value).map_err(|e| JsError::new(&e.to_string()))?;
     Ok(js_value)
@@ -190,13 +190,12 @@ pub fn parse_cbor(data: &[u8]) -> Result<JsValue, JsError> {
 pub fn serialize_cbor(js_value: &JsValue) -> Result<Vec<u8>, JsError> {
     let value: Value = serde_wasm_bindgen::from_value(js_value.clone())
         .map_err(|e| JsError::new(&e.to_string()))?;
-    let cbor_bytes =
-        serde_ipld_dagcbor::to_vec(&value).map_err(|e| JsError::new(&e.to_string()))?;
+    let cbor_bytes = serde_cbor_core::to_vec(&value).map_err(|e| JsError::new(&e.to_string()))?;
     Ok(cbor_bytes)
 }
 
 /// Validate that data is valid CBOR
 #[wasm_bindgen]
 pub fn is_valid_cbor(data: &[u8]) -> bool {
-    serde_ipld_dagcbor::from_slice::<Value>(data).is_ok()
+    serde_cbor_core::from_slice::<Value>(data).is_ok()
 }

--- a/rust/szdt-wasm/src/memo.rs
+++ b/rust/szdt-wasm/src/memo.rs
@@ -88,7 +88,7 @@ impl Memo {
     #[wasm_bindgen]
     pub fn to_cbor(&self) -> Result<Vec<u8>, JsError> {
         let bytes =
-            serde_ipld_dagcbor::to_vec(&self.inner).map_err(|e| JsError::new(&e.to_string()))?;
+            serde_cbor_core::to_vec(&self.inner).map_err(|e| JsError::new(&e.to_string()))?;
         Ok(bytes)
     }
 
@@ -96,7 +96,7 @@ impl Memo {
     #[wasm_bindgen]
     pub fn from_cbor(data: &[u8]) -> Result<Memo, JsError> {
         let inner: CoreMemo =
-            serde_ipld_dagcbor::from_slice(data).map_err(|e| JsError::new(&e.to_string()))?;
+            serde_cbor_core::from_slice(data).map_err(|e| JsError::new(&e.to_string()))?;
         Ok(Self { inner })
     }
 


### PR DESCRIPTION
https://crates.io/crates/serde_cbor_core is a hard fork of serde_ipld_dagcbor that

- removes the ipld bits
- updates behavior for spec compatibility with https://www.rfc-editor.org/rfc/rfc8949.html and https://datatracker.ietf.org/doc/draft-rundgren-cbor-core/

This PR brings us into alignment with the spec (CBOR/c serialization) and reduces deps too.